### PR TITLE
Bugfix: Empty comments by typing backslashes

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -66,6 +66,31 @@ function comment_pagetitle($val, $sep) {
 remove_filter('wp_title', 'index_permatitle');
 add_filter('wp_title', 'comment_pagetitle', 10, 2);
 
+/**
+ * Bugfix: Empty comments no longer can be posted by typing a single backslash ('\') into the formular.
+ * 
+ * This function replaces every single backslash '\' with an escaped one '\\'.
+ * Due to the fact, that PHP already escapes the backslashes in the code we have to replace '\\' with '\\\\'.
+ * 
+ * When the function is called with '$escapeSlashes = TRUE' the backslahes in the printed comment area are escaped aswell, 
+ * so when typing a single one '\' it wont post a comment because of "You must enter a comment". and when typing in '\\' it will print only '\'.
+ * 
+ * Default is '$escapeSlashes = false'.
+ * This way every backslash is commented in the very exact way it was written into the formular.
+ * 
+ * @author Illevyard
+ * @param string $string
+ * @param boolean $mode
+ */
+function comment_backslashFix($string, $escapeSlashes = false) {
+    $content = $string;
+    if ($escapeSlashes === true) {
+        stripslashes($content);
+    }
+    $fixedContent = trim(str_replace('\\', '\\\\', $content));
+    return $fixedContent;
+}
+
 function comment_validate() {
 	global $smarty, $lang;
 	
@@ -82,7 +107,10 @@ function comment_validate() {
 	 * );
 	 */
 	
-	$content = isset($_POST ['content']) ? trim(stripslashes($_POST ['content'])) : null;
+	if (isset($_POST['content'])) {
+	    $content = $_POST['content'];
+	    $content = comment_backslashFix($content);
+	}
 	
 	$errors = array();
 	


### PR DESCRIPTION
You can post empty comments by typing a single backslash into the formular.
I fixed this bug with an additional function `function comment_backslashFix($string, $escapeSlashes = false)`, which escapes every backslash in the given string `$string` so it can be displayed properly.

Here's an Example on how the function works:

OLD:
`input: '\' → '\'`
`print-out: ' ' (empty string - something got escaped, but not what we wanted to)` 

FIXED
WITH "`$escapeSlashes = false`":
`input: '\' → '\\' `
`print-out: '\' (escaped backslash!)`
`input: '\\' → '\\\\' `
`print-out: '\\' (two escaped backslashes!)`


You can toggle `$escapeSlashes = true` if you want the backslashes to be stripped, but dont want to be able to post empty comments

OLD:
`input: '\' → '\'`
`print-out: ' ' (empty string - something got escaped, but not what we wanted to)` 

FIXED  
WITH "`$escapeSlashes = true`":
`input: '\' → ' '`
`print-out: ' ' → "Error: You must enter a comment"`
`input: '\\' → '\' `
`printed: '\'`